### PR TITLE
remove alloc_16 && add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+TARGET 		:= riscv64gc-unknown-none-elf
+MODE		:= debug
+
+GUEST  		:= guest/target/$(TARGET)/$(MODE)/riscv-virt-guest
+
+$(GUEST):
+	cd guest && cargo build
+
+run: $(GUEST)
+	cd hypervisor && cargo run -- -drive file=../guest/target/riscv64gc-unknown-none-elf/debug/riscv-virt-guest,if=none,format=raw,id=x0 -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
+
+clean:
+	cd hypervisor && cargo clean 
+	cd guest && cargo clean

--- a/guest/src/kernel.rs
+++ b/guest/src/kernel.rs
@@ -36,7 +36,7 @@ pub extern "C" fn rust_entrypoint() -> ! {
 fn setup_vm() {
     paging::init();
 
-    let root_page = paging::alloc_16();
+    let root_page = paging::alloc();
     println!(
         "a page 0x{:016x} was allocated for a guest page address translation page table",
         root_page.address().to_usize()

--- a/guest/src/paging.rs
+++ b/guest/src/paging.rs
@@ -148,21 +148,7 @@ pub fn alloc() -> Page {
     }
 }
 
-/// Makes sure the root page follows a 16KiB boundry
-pub fn alloc_16() -> Page {
-    let mut root_page = alloc();
-    while root_page.address().to_usize() & (0b11_1111_1111_1111 as usize) > 0 {
-        log::debug!(
-            "a page 0x{:016x} was allocated, but it does not follow 16KiB boundary. drop.",
-            root_page.address().to_usize()
-        );
-        root_page = alloc();
-    }
-    alloc();
-    alloc();
-    alloc();
-    root_page
-}
+
 
 pub fn alloc_continuous(num: usize) -> Page {
     if num <= 0 {


### PR DESCRIPTION
This PR slove the following issues:
- There is no need to align the root page table to 16 KiB in the guest, remove `alloc_16` for memory space.
- Add Makefile to help run